### PR TITLE
Fixed typo in Perceptron chapter

### DIFF
--- a/book/perc.tex
+++ b/book/perc.tex
@@ -828,7 +828,7 @@ we start with $D$-many features, if we want to add all pairs, we'll
 blow up to ${D \choose 2} = \cO(D^2)$ features through this
 \concept{feature mapping}.  And there's no guarantee that pairs of
 features is enough.  We might need triples of features, and now we're
-up to ${D \choose 3} = \cO(D^2)$ features.  These additional features
+up to ${D \choose 3} = \cO(D^3)$ features.  These additional features
 will drastically increase computation and will often result in a
 stronger propensity to overfitting.
 


### PR DESCRIPTION
D choose 3 is O(D^3) not O(D^2) as mistakenly mentioned in the book