### PR TITLE
fixed algorithm numbering

### DIFF
--- a/book/halbook.tex
+++ b/book/halbook.tex
@@ -472,15 +472,21 @@
 
 \floatname{algorithm}{\textcolor{\algorithmiccolor}{\algorithmicfont Algorithm}}
 
+\makeatletter
+\@addtoreset{algorithm}{chapter}% algorithm counter resets every chapter
+\makeatother
+
+\renewcommand{\thealgorithm}{\arabic{chapter}.\arabic{algorithm}}
+
 \newcommand{\newalgorithm}[3]{%
   \begin{algorithm}[t]
-    \label{alg:#1}
-    \caption{#2}
     \begin{small}
       \begin{algorithmic}[1]
         #3
       \end{algorithmic}
     \end{small}
+    \caption{#2}
+	\label{alg:#1}
   \end{algorithm}}
 
 \newcommand{\categ}[1]{\textsc{\textcolor{darkgrey}{#1}}}


### PR DESCRIPTION
In the current version of the book, there is a mismatch between the algorithm numbers referenced in the text and the numbering in the actual algorithms.

For example, DecisionTreeTrain is labeled as Algorithm 1, but is referenced as Algorithm 1.3 and DecisionTreeTest is labeled as Algorithm 2 and is also referenced as Algorithm 1.3.

This PR addresses the issue with algorithm numbering. The algorithms are now numbered sequentially by chapter, e.g. 1.1, 1.2, 1.3... 2.1, 2.2, 2.3.

This fixes #215, #226, #174, and #126.

Thanks to @breiche in my lab for the fix.