### PR TITLE
Apply proper sqrt on both sides in the proof of Perceptron Convergenc…

### DIFF
--- a/book/perc.tex
+++ b/book/perc.tex
@@ -586,7 +586,7 @@ between them has to be shrinking.  The rest is algebra.
 
   Now we put together the two things we have learned before.  By our
   first conclusion, we know $\dotp{\vw^*}{\vw\kth} \geq k \ga$.  But
-  our second conclusion, $\sqrt{k} \geq \norm{\vw\kth}^2$.  Finally,
+  our second conclusion, $\sqrt{k} \geq \norm{\vw\kth}$.  Finally,
   because $\vw^*$ is a unit vector, we know that $\norm{\vw\kth} \geq
   \dotp{\vw^*}{\vw\kth}$.  Putting this together, we have:
   \begin{equation}


### PR DESCRIPTION
…e Theorem.

In the book, there is a conclusion that
||w(k)||^2 ≤ k.

Then later it is referred to sometimes as ||w(k)||^2 ≤ sqrt(k) and sometimes ||w(k)|| ≤ sqrt(k). Fixing this.